### PR TITLE
Added a podspec

### DIFF
--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -28,13 +28,6 @@ Pod::Spec.new do |s|
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.source_files = "OSRMTextInstructions"
-
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
-  s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target = "9.0"
   
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -4,10 +4,10 @@ Pod::Spec.new do |s|
 
   s.name = "OSRMTextInstructions"
   s.version = "0.0.1"
-  s.summary = "osrm-text-instructions parser for Swift and Objective-C."
+  s.summary = "Transforms OSRM route reponses into human-readable instructions."
 
   s.description  = <<-DESC
-  OSRMTextInstructions is a library that transforms OSRM route responses into localized text instructions.
+  OSRMTextInstructions transforms OSRM route responses into localized, human-readable turn-by-turn instructions. Primarily intended for use with MapboxDirections.swift.
                 DESC
 
   s.homepage = "http://project-osrm.org/"

--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -1,0 +1,52 @@
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.name = "OSRMTextInstructions"
+  s.version = "0.0.1"
+  s.summary = "osrm-text-instructions parser for Swift and Objective-C."
+
+  s.description  = <<-DESC
+  OSRMTextInstructions is a library that transforms OSRM route responses into localized text instructions.
+                DESC
+
+  s.homepage = "http://project-osrm.org/"
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.license = { :type => "BSD", :file => "LICENSE.md" }
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.author = { "Mapbox" => "mobile@mapbox.com" }
+  s.social_media_url   = "https://twitter.com/mapbox"
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.source = { :git => "https://github.com/Project-OSRM/osrm-text-instructions.swift.git", :tag => "v#{s.version.to_s}" }
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.source_files = "OSRMTextInstructions"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+  
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.requires_arc = true
+  s.module_name = "OSRMTextInstructions"
+
+  s.dependency "MapboxDirections.swift"
+
+  s.xcconfig = {
+    "SWIFT_VERSION" => "3.0"
+  }
+
+end
+
+


### PR DESCRIPTION
OSRMTextInstructions can now be installed with CocoaPods.

We can lower the deployment target when we've added availability macros for the use of NSNumberFormatter.ordinal.
@1ec5 👀 