### PR TITLE
Deploy back to iOS 8.0

### DIFF
--- a/OSRMTextInstructions.xcodeproj/project.pbxproj
+++ b/OSRMTextInstructions.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -399,7 +399,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -426,7 +426,6 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/OSRMTextInstructions/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.project-osrm.OSRMTextInstructions.swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -452,7 +451,6 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/OSRMTextInstructions/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.project-osrm.OSRMTextInstructions.swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -28,7 +28,9 @@ public class OSRMInstructionFormatter: Formatter {
     let ordinalFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.locale = .current
-        formatter.numberStyle = .ordinal
+        if #available(iOS 9.0, OSX 10.11, *) {
+            formatter.numberStyle = .ordinal
+        }
         return formatter
     }()
     


### PR DESCRIPTION
Ordinal number formatting is for iOS 9.0 and above; iOS 8.x gets cardinal numbers.

/cc @freenerd