### PR TITLE
Fix paths, deployment targets in CocoaPods podspec

### DIFF
--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -21,6 +21,14 @@ Pod::Spec.new do |s|
   s.author = { "Mapbox" => "mobile@mapbox.com" }
   s.social_media_url   = "https://twitter.com/mapbox"
 
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  #  When using multiple platforms
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.10"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.source = { :git => "https://github.com/Project-OSRM/osrm-text-instructions.swift.git", :tag => "v#{s.version.to_s}" }

--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.resources = ['OSRMTextInstructions/*.plist']
+  s.resources = ['OSRMTextInstructions/*.lproj/*.plist']
   
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Updated the CocoaPods podspec to reflect the movement of Instructions.plist in #11. Also added minimum deployment targets to the podspec so the library is explicitly supported on all four platforms (at least via CocoaPods; see #5 for the Carthage side). Now the podspec lints except for the fact that these fixes haven’t been tagged in a release yet.

Fixes #12.