### PR TITLE
Pin version for MapboxDirections.swift

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" "master"
+github "mapbox/MapboxDirections.swift" ~> 0.8


### PR DESCRIPTION
Ran into this Carthage issue because we specified the master branch
```
Could not pick a version for github "mapbox/MapboxDirections.swift", due to mutually incompatible requirements:
"master" (github "Project-OSRM/osrm-text-instructions.swift")
```