### PR TITLE
Remove build settings override

### DIFF
--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -50,8 +50,4 @@ Pod::Spec.new do |s|
 
   s.prepare_command = "./json2plist.sh"
 
-  s.xcconfig = {
-    "SWIFT_VERSION" => "3.0"
-  }
-
 end


### PR DESCRIPTION
CocoaPods parses `SWIFT_VERSION` correctly from the target now so there's no need to override.

@bsudekum 👀 