### PR TITLE
Port OSRM Text Instructions to v0.5.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" ~> 0.9
+github "mapbox/MapboxDirections.swift" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "v0.9.0"
+github "mapbox/MapboxDirections.swift" "v0.10.0"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "OSRMTextInstructions"
 
-  s.dependency "MapboxDirections.swift", "~> 0.9"
+  s.dependency "MapboxDirections.swift", "~> 0.10"
 
   s.prepare_command = "./json2plist.sh"
 

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -212,7 +212,11 @@ public class OSRMInstructionFormatter: Formatter {
         // Decide which instruction string to use
         // Destination takes precedence over name
         var instruction: String
-        if let _ = step.destinations, let obj = instructionObject["destination"] {
+        if let _ = step.destinations, let _ = step.exitCodes?.first, let obj = instructionObject["exit_destination"] {
+            instruction = obj
+        } else if let _ = step.destinations, let obj = instructionObject["destination"] {
+            instruction = obj
+        } else if let _ = step.exitCodes?.first, let obj = instructionObject["exit"] {
             instruction = obj
         } else if !wayName.isEmpty, let obj = instructionObject["name"] {
             instruction = obj
@@ -225,10 +229,11 @@ public class OSRMInstructionFormatter: Formatter {
         if let legIndex = legIndex, let numberOfLegs = numberOfLegs, legIndex != numberOfLegs - 1 {
             nthWaypoint = ordinalFormatter.string(from: (legIndex + 1) as NSNumber)
         }
+        let exitCode = step.exitCodes?.first ?? ""
         let destination = step.destinations?.first ?? ""
-        var exit: String = ""
+        var exitOrdinal: String = ""
         if let exitIndex = step.exitIndex, exitIndex <= 10 {
-            exit = ordinalFormatter.string(from: exitIndex as NSNumber)!
+            exitOrdinal = ordinalFormatter.string(from: exitIndex as NSNumber)!
         }
         let modifierConstants = constants["modifier"] as! [String: String]
         let modifierConstant = modifierConstants[modifier ?? "straight"]!
@@ -260,7 +265,8 @@ public class OSRMInstructionFormatter: Formatter {
                     switch tokenType {
                     case .wayName: replacement = wayName
                     case .destination: replacement = destination
-                    case .exit: replacement = exit
+                    case .exitCode: replacement = exitCode
+                    case .exitIndex: replacement = exitOrdinal
                     case .rotaryName: replacement = rotaryName
                     case .laneInstruction: replacement = laneInstruction ?? ""
                     case .modifier: replacement = modifierConstant

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -121,10 +121,10 @@ public class OSRMInstructionFormatter: Formatter {
     typealias InstructionsByModifier = [String: InstructionsByToken]
     
     override public func string(for obj: Any?) -> String? {
-        return string(for: obj, modifyValueByKey: nil)
+        return string(for: obj, legIndex: nil, numberOfLegs: nil, modifyValueByKey: nil)
     }
     
-    public func string(for obj: Any?, modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
+    public func string(for obj: Any?, legIndex: Int?, numberOfLegs: Int?, modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
         guard let step = obj as? RouteStep else {
             return nil
         }
@@ -221,7 +221,10 @@ public class OSRMInstructionFormatter: Formatter {
         }
 
         // Prepare token replacements
-        let nthWaypoint = "" // TODO: add correct waypoint counting
+        var nthWaypoint: String? = nil
+        if let legIndex = legIndex, let numberOfLegs = numberOfLegs, legIndex != numberOfLegs - 1 {
+            nthWaypoint = ordinalFormatter.string(from: (legIndex + 1) as NSNumber)
+        }
         let destination = step.destinations?.first ?? ""
         var exit: String = ""
         if let exitIndex = step.exitIndex, exitIndex <= 10 {
@@ -262,7 +265,7 @@ public class OSRMInstructionFormatter: Formatter {
                     case .laneInstruction: replacement = laneInstruction ?? ""
                     case .modifier: replacement = modifierConstant
                     case .direction: replacement = directionFromDegree(degree: bearing)
-                    case .wayPoint: replacement = nthWaypoint
+                    case .wayPoint: replacement = nthWaypoint ?? ""
                     }
                     if tokenType == .wayName {
                         result += replacement // already modified above

--- a/OSRMTextInstructions/TokenType.swift
+++ b/OSRMTextInstructions/TokenType.swift
@@ -6,7 +6,8 @@ public enum TokenType: Int, CustomStringConvertible {
     case wayName
     case destination
     case rotaryName
-    case exit
+    case exitCode
+    case exitIndex
     case laneInstruction
     case modifier
     case direction
@@ -21,8 +22,10 @@ public enum TokenType: Int, CustomStringConvertible {
             type = .destination
         case "rotary_name":
             type = .rotaryName
+        case "exit":
+            type = .exitCode
         case "exit_number":
-            type = .exit
+            type = .exitIndex
         case "lane_instruction":
             type = .laneInstruction
         case "modifier":
@@ -45,7 +48,9 @@ public enum TokenType: Int, CustomStringConvertible {
             return "destination"
         case .rotaryName:
             return "rotary_name"
-        case .exit:
+        case .exitCode:
+            return "exit"
+        case .exitIndex:
             return "exit_number"
         case .laneInstruction:
             return "lane_instruction"

--- a/OSRMTextInstructions/TokenType.swift
+++ b/OSRMTextInstructions/TokenType.swift
@@ -29,7 +29,7 @@ public enum TokenType: Int, CustomStringConvertible {
             type = .modifier
         case "direction":
             type = .direction
-        case "way_point":
+        case "nth":
             type = .wayPoint
         default:
             return nil
@@ -54,7 +54,7 @@ public enum TokenType: Int, CustomStringConvertible {
         case .direction:
             return "direction"
         case .wayPoint:
-            return "way_point"
+            return "nth"
         }
     }
 }

--- a/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
+++ b/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
@@ -1,9 +1,16 @@
 import XCTest
 import MapboxDirections
-import OSRMTextInstructions
+@testable import OSRMTextInstructions
 
 class OSRMTextInstructionsTests: XCTestCase {
     let instructions = OSRMInstructionFormatter(version: "v5")
+    
+    override func setUp() {
+        super.setUp()
+        
+        // Force an English locale to match the fixture language rather than the test machine’s language.
+        instructions.ordinalFormatter.locale = Locale(identifier: "en-US")
+    }
 
     func testSentenceCasing() {
         XCTAssertEqual("Capitalized String", "capitalized String".sentenceCased)
@@ -27,11 +34,12 @@ class OSRMTextInstructionsTests: XCTestCase {
                         XCTAssert(false, "invalid json")
                         return
                     }
+                    let options = json["options"] as? [String: Int]
 
                     let step = RouteStep(json: json["step"] as! [String: Any])
 
                     // compile instruction
-                    let instruction = instructions.string(for: step)
+                    let instruction = instructions.string(for: step, legIndex: options?["legIndex"], numberOfLegs: options?["legCount"], modifyValueByKey: nil)
 
                     // check generated instruction against fixture
                     XCTAssertEqual(
@@ -107,6 +115,7 @@ class OSRMTextInstructionsTests: XCTestCase {
         fixture["step"] = step
         fixture["instruction"] = (json["instructions"] as! [ String: Any ])["en"] as! String
 
+        fixture["options"] = json["options"]
         return fixture
     }
 }

--- a/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
+++ b/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
@@ -86,6 +86,9 @@ class OSRMTextInstructionsTests: XCTestCase {
         if let ref = jsonStep["ref"] {
             step["ref"] = ref
         }
+        if let exits = jsonStep["exits"] {
+            step["exits"] = exits
+        }
         if let destinations = jsonStep["destinations"] {
             step["destinations"] = destinations
         }


### PR DESCRIPTION
This PR gets the Swift library back in sync with the JavaScript library, upgrading it from v0.2.1 to Project-OSRM/osrm-text-instructions@020e28befe940df360670d01c6b1e3c7d3fb4c0a, which is equivalent to [v0.4.0](https://github.com/Project-OSRM/osrm-text-instructions/releases/tag/v0.4.0) plus Project-OSRM/osrm-text-instructions#116 and some translation updates. To wit, this PR makes the following changes:

* [x] Updates translations, bringing in:
   * A new Indonesian localization (Project-OSRM/osrm-text-instructions#104)
   * A new Polish localization (Project-OSRM/osrm-text-instructions#120)
   * Updates to the German localization (Project-OSRM/osrm-text-instructions#122)
   * Updates to the Vietnamese localization (Project-OSRM/osrm-text-instructions#123)
* [x] When there are multiple legs in the route, an intermediate waypoint’s arrival instruction correctly identifies the waypoint by its ordinal (fixes #24)
   * Added optional arguments to `OSRMInstructionFormatter.string(for:modifyValueByKey:)` to track which leg the instruction is on.
   * Fixed the raw value of `TokenType.wayPoint`.
* [x] An instruction to take an off-ramp indicates the exit number where available (fixes #25)
   * Added `TokenType.exitCode`.
   * Renamed `TokenType.exit` to `exitIndex` for clarity.
* [x] The unit tests force the ordinal formatter to use the fixture language (English) rather than the test machine’s language, allowing the tests to finally pass on my machine 🎉
* [x] Revert Cartfile to point to a MapboxDirections.swift release again, once mapbox/MapboxDirections.swift#147 lands

(Project-OSRM/osrm-text-instructions#107 is irrelevant to this library because `Bundle` handles language fallbacks in Swift.)

Depends on mapbox/MapboxDirections.swift#147, ~~which is on hold until the `exits` property lands in the production Directions API~~.

/cc @bsudekum @freenerd @willwhite