### PR TITLE
Use ref when way is motorway

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" "647e4ecf8c3c75041cc3cd2985b2c3aaf611bdf9"
+github "mapbox/MapboxDirections.swift" "2864d7ac9225fa92d84ecbae93fb9d979e5a4566"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" ~> 0.10
+github "mapbox/MapboxDirections.swift" "647e4ecf8c3c75041cc3cd2985b2c3aaf611bdf9"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" "2864d7ac9225fa92d84ecbae93fb9d979e5a4566"
+github "mapbox/MapboxDirections.swift" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "v0.10.0"
+github "mapbox/MapboxDirections.swift" "647e4ecf8c3c75041cc3cd2985b2c3aaf611bdf9"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "647e4ecf8c3c75041cc3cd2985b2c3aaf611bdf9"
+github "mapbox/MapboxDirections.swift" "2864d7ac9225fa92d84ecbae93fb9d979e5a4566"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "2864d7ac9225fa92d84ecbae93fb9d979e5a4566"
+github "mapbox/MapboxDirections.swift" "v0.10.1"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -187,8 +187,8 @@ public class OSRMInstructionFormatter: Formatter {
             
             if let name = name, let ref = ref, name != ref, !isMotorWay {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, name)) (\(modifyValueByKey!(.wayName, ref)))" : "\(name) (\(ref))"
-            } else if let ref = ref, isMotorWay, let decimalRange = ref.rangeOfCharacter(from: CharacterSet.decimalDigits), !decimalRange.isEmpty {
-                wayName = ref;
+            } else if let ref = ref, isMotorWay, let decimalRange = ref.rangeOfCharacter(from: .decimalDigits), !decimalRange.isEmpty {
+                wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, ref))" : ref
             } else if name == nil, let ref = ref {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, ref))" : ref
             } else {

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -124,7 +124,17 @@ public class OSRMInstructionFormatter: Formatter {
         return string(for: obj, legIndex: nil, numberOfLegs: nil, roadClasses: nil, modifyValueByKey: nil)
     }
     
-    public func string(for obj: Any?, legIndex: Int?, numberOfLegs: Int?, roadClasses: RoadClasses?, modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
+    /**
+     Creates an instruction given a step and options.
+     
+     - parameter step: 
+     - parameter legIndex: Current leg index the user is currently on.
+     - parameter numberOfLegs: Total number of `RouteLeg` for the given `Route`.
+     - parameter roadClasses: Option set representing the classes of road for the `RouteStep`.
+     - parameter modifyValueByKey: Allows for mutating the instruction at given parts of the instruction.
+     - returns: An instruction as a `String`.
+     */
+    public func string(for obj: Any?, legIndex: Int?, numberOfLegs: Int?, roadClasses: RoadClasses? = RoadClasses([]), modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
         guard let step = obj as? RouteStep else {
             return nil
         }
@@ -179,15 +189,11 @@ public class OSRMInstructionFormatter: Formatter {
             // Set wayName
             let name = step.names?.first
             let ref = step.codes?.first
-            var isMotorWay = false
+            let isMotorway = roadClasses?.contains(.motorway) ?? false
             
-            if let roadClasses = roadClasses, roadClasses.contains(.motorway) {
-                isMotorWay = true
-            }
-            
-            if let name = name, let ref = ref, name != ref, !isMotorWay {
+            if let name = name, let ref = ref, name != ref, !isMotorway {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, name)) (\(modifyValueByKey!(.wayName, ref)))" : "\(name) (\(ref))"
-            } else if let ref = ref, isMotorWay, let decimalRange = ref.rangeOfCharacter(from: .decimalDigits), !decimalRange.isEmpty {
+            } else if let ref = ref, isMotorway, let decimalRange = ref.rangeOfCharacter(from: .decimalDigits), !decimalRange.isEmpty {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, ref))" : ref
             } else if name == nil, let ref = ref {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, ref))" : ref

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -121,10 +121,10 @@ public class OSRMInstructionFormatter: Formatter {
     typealias InstructionsByModifier = [String: InstructionsByToken]
     
     override public func string(for obj: Any?) -> String? {
-        return string(for: obj, legIndex: nil, numberOfLegs: nil, modifyValueByKey: nil)
+        return string(for: obj, legIndex: nil, numberOfLegs: nil, roadClasses: nil, modifyValueByKey: nil)
     }
     
-    public func string(for obj: Any?, legIndex: Int?, numberOfLegs: Int?, modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
+    public func string(for obj: Any?, legIndex: Int?, numberOfLegs: Int?, roadClasses: RoadClasses?, modifyValueByKey: ((TokenType, String) -> String)?) -> String? {
         guard let step = obj as? RouteStep else {
             return nil
         }
@@ -179,9 +179,16 @@ public class OSRMInstructionFormatter: Formatter {
             // Set wayName
             let name = step.names?.first
             let ref = step.codes?.first
+            var isMotorWay = false
             
-            if let name = name, let ref = ref, name != ref {
+            if let roadClasses = roadClasses, roadClasses.contains(.motorway) {
+                isMotorWay = true
+            }
+            
+            if let name = name, let ref = ref, name != ref, !isMotorWay {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, name)) (\(modifyValueByKey!(.wayName, ref)))" : "\(name) (\(ref))"
+            } else if let ref = ref, isMotorWay, let decimalRange = ref.rangeOfCharacter(from: CharacterSet.decimalDigits), !decimalRange.isEmpty {
+                wayName = ref;
             } else if name == nil, let ref = ref {
                 wayName = modifyValueByKey != nil ? "\(modifyValueByKey!(.wayName, ref))" : ref
             } else {

--- a/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
+++ b/OSRMTextInstructionsTests/OSRMTextInstructionsTests.swift
@@ -34,12 +34,17 @@ class OSRMTextInstructionsTests: XCTestCase {
                         XCTAssert(false, "invalid json")
                         return
                     }
-                    let options = json["options"] as? [String: Int]
+                    let options = json["options"] as? [String: Any]
 
                     let step = RouteStep(json: json["step"] as! [String: Any])
+                    
+                    var roadClasses: RoadClasses? = nil
+                    if let classes = options?["classes"] as? [String] {
+                        roadClasses = RoadClasses(descriptions: classes)
+                    }
 
                     // compile instruction
-                    let instruction = instructions.string(for: step, legIndex: options?["legIndex"], numberOfLegs: options?["legCount"], modifyValueByKey: nil)
+                    let instruction = instructions.string(for: step, legIndex: options?["legIndex"] as? Int, numberOfLegs: options?["legCount"] as? Int, roadClasses: roadClasses, modifyValueByKey: nil)
 
                     // check generated instruction against fixture
                     XCTAssertEqual(


### PR DESCRIPTION
Based off of https://github.com/Project-OSRM/osrm-text-instructions/pull/129

- [x] prerequisite: https://github.com/mapbox/MapboxDirections.swift/pull/154


If the road class is a motorway and the ref contains a number, we should announce the ref and not the name since it could be the ceremonial name.

/cc @1ec5 @freenerd @willwhite 