### PR TITLE
osrm-text-instructions v0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode8.3
 cache:
   directories:
   - Carthage

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "v0.10.1"
+github "mapbox/MapboxDirections.swift" "v0.10.4"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/OSRMTextInstructions/TokenType.swift
+++ b/OSRMTextInstructions/TokenType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc(OSRMTokenType)
 public enum TokenType: Int, CustomStringConvertible {
-    
+    // For individual instructions
     case wayName
     case destination
     case rotaryName
@@ -14,10 +14,15 @@ public enum TokenType: Int, CustomStringConvertible {
     case wayPoint
     case code
     
+    // For phrases
+    case firstInstruction
+    case secondInstruction
+    case distance
+    
     public init?(description: String) {
         let type: TokenType
         switch description {
-        case "way_name":
+        case "way_name", "name":
             type = .wayName
         case "destination":
             type = .destination
@@ -37,6 +42,12 @@ public enum TokenType: Int, CustomStringConvertible {
             type = .wayPoint
         case "ref":
             type = .code
+        case "instruction_one":
+            type = .firstInstruction
+        case "instruction_two":
+            type = .secondInstruction
+        case "distance":
+            type = .distance
         default:
             return nil
         }
@@ -65,6 +76,12 @@ public enum TokenType: Int, CustomStringConvertible {
             return "nth"
         case .code:
             return "ref"
+        case .firstInstruction:
+            return "instruction_one"
+        case .secondInstruction:
+            return "instruction_two"
+        case .distance:
+            return "distance"
         }
     }
 }


### PR DESCRIPTION
Upgraded to MapboxDirections.swift v0.10.4 and OSRM Text Instructions v0.7.0.

Added some cases for phrase-specific tokens to `TokenType`. Extracted token replacement code for a `String` extension method. Added tests for token substitution in phrases. Simplified test code.

Fixes #37.

/cc @bsudekum @mcwhittemore