### PR TITLE
Attributed string formatting

### DIFF
--- a/OSRMTextInstructions.xcodeproj/project.pbxproj
+++ b/OSRMTextInstructions.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		358D145A1E5E355600ADE590 /* OSRMTextInstructions.h in Headers */ = {isa = PBXBuildFile; fileRef = 358D14571E5E355600ADE590 /* OSRMTextInstructions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		358D145B1E5E355600ADE590 /* OSRMTextInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D14581E5E355600ADE590 /* OSRMTextInstructions.swift */; };
 		C51B63E91E65FA04002F4634 /* TokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51B63E81E65FA04002F4634 /* TokenType.swift */; };
+		DA5F02781F6CBAAF0040C4AD /* TokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F02771F6CBAAF0040C4AD /* TokenTests.swift */; };
+		DA5F02791F6CBAAF0040C4AD /* TokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F02771F6CBAAF0040C4AD /* TokenTests.swift */; };
+		DA5F027A1F6CBAAF0040C4AD /* TokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F02771F6CBAAF0040C4AD /* TokenTests.swift */; };
 		DA5F589C1E85A32C00BA4D0A /* OSRMTextInstructions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5F58931E85A32C00BA4D0A /* OSRMTextInstructions.framework */; };
 		DA5F58AB1E85B0A000BA4D0A /* OSRMTextInstructions.h in Headers */ = {isa = PBXBuildFile; fileRef = 358D14571E5E355600ADE590 /* OSRMTextInstructions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA5F58AC1E85B0A500BA4D0A /* OSRMTextInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D14581E5E355600ADE590 /* OSRMTextInstructions.swift */; };
@@ -80,6 +83,7 @@
 		35EBDB5D1E5E1572006EB3CD /* OSRMTextInstructions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OSRMTextInstructions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C51B63E81E65FA04002F4634 /* TokenType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenType.swift; sourceTree = "<group>"; };
 		DA2DFB3B1E8373AF00CEEBE9 /* json2plist.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = json2plist.sh; sourceTree = "<group>"; };
+		DA5F02771F6CBAAF0040C4AD /* TokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenTests.swift; sourceTree = SOURCE_ROOT; };
 		DA5F58931E85A32C00BA4D0A /* OSRMTextInstructions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OSRMTextInstructions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5F589B1E85A32C00BA4D0A /* OSRMTextInstructionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSRMTextInstructionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5F58B61E85B24E00BA4D0A /* MapboxDirections.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxDirections.framework; path = Carthage/Build/Mac/MapboxDirections.framework; sourceTree = "<group>"; };
@@ -177,8 +181,9 @@
 		352BBC2A1E5E4D4200703DF1 /* OSRMTextInstructionsTests */ = {
 			isa = PBXGroup;
 			children = (
-				352BBC2B1E5E4D4200703DF1 /* OSRMTextInstructionsTests.swift */,
 				352BBC2D1E5E4D4200703DF1 /* Info.plist */,
+				352BBC2B1E5E4D4200703DF1 /* OSRMTextInstructionsTests.swift */,
+				DA5F02771F6CBAAF0040C4AD /* TokenTests.swift */,
 			);
 			path = OSRMTextInstructionsTests;
 			sourceTree = "<group>";
@@ -637,6 +642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA5F02781F6CBAAF0040C4AD /* TokenTests.swift in Sources */,
 				352BBC2C1E5E4D4200703DF1 /* OSRMTextInstructionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -665,6 +671,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA5F02791F6CBAAF0040C4AD /* TokenTests.swift in Sources */,
 				DA5F58AE1E85B0AE00BA4D0A /* OSRMTextInstructionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -683,6 +690,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA5F027A1F6CBAAF0040C4AD /* TokenTests.swift in Sources */,
 				DA5F58E61E85BE1900BA4D0A /* OSRMTextInstructionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OSRMTextInstructions.xcodeproj/xcshareddata/xcschemes/OSRMTextInstructions macOS.xcscheme
+++ b/OSRMTextInstructions.xcodeproj/xcshareddata/xcschemes/OSRMTextInstructions macOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -34,15 +34,18 @@ extension String: Tokenized {
             
             var token: NSString?
             guard scanner.scanUpTo("}", into: &token) else {
+                result += "{"
                 continue
             }
             
             if scanner.scanString("}", into: nil) {
                 if let tokenType = TokenType(description: token! as String) {
                     result += interpolator(tokenType)
+                } else {
+                    result += "{\(token!)}"
                 }
             } else {
-                result += token! as String
+                result += "{\(token!)"
             }
         }
         

--- a/TokenTests.swift
+++ b/TokenTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import OSRMTextInstructions
+
+class TokenTests: XCTestCase {
+    func testReplacingTokens() {
+        XCTAssertEqual("Dead Beef", "Dead Beef".replacingTokens { _ in "" })
+        XCTAssertEqual("Food", "F{ref}{ref}d".replacingTokens { _ in "o" })
+        
+        XCTAssertEqual("Take the left stairs to the 20th floor", "Take the {modifier} stairs to the {nth} floor".replacingTokens { (tokenType) -> String in
+            switch tokenType {
+            case .modifier:
+                return "left"
+            case .wayPoint:
+                return "20th"
+            default:
+                XCTAssert(false)
+                return "wrong"
+            }
+        })
+        
+        XCTAssertEqual("{👿}", "{👿}".replacingTokens { _ in "👼" })
+        XCTAssertEqual("{", "{".replacingTokens { _ in "🕳" })
+        XCTAssertEqual("{💣", "{💣".replacingTokens { _ in "🕳" })
+        XCTAssertEqual("}", "}".replacingTokens { _ in "🕳" })
+    }
+}


### PR DESCRIPTION
Added a new variant of `OSRMInstructionFormatter.string(for:legIndex:numberOfLegs:roadClasses:modifyValueByKey:)` that deals in [NSAttributedString](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/AttributedStrings/AttributedStrings.html) instead of String. NSAttributedString is the native rich text object model on Apple platforms, the only one that requires no custom parsing code to work with. Some serving suggestions:

* Set important substrings like street names in bold or make them larger than the surrounding text.
* Prevent line breaking within road names.
* Replace road codes with pictorial route shields inline (mapbox/mapbox-navigation-ios#365).
* Apply [pronunciation hints](https://developer.apple.com/documentation/avfoundation/avspeechsynthesisipanotationattribute) to street names for use by AVSpeechSynthesis or VoiceOver.

Depends on #38.

/cc @frederoni @bsudekum