### PR TITLE
Add phrase lookup method

### DIFF
--- a/OSRMTextInstructions.xcodeproj/project.pbxproj
+++ b/OSRMTextInstructions.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		DA5F58FE1E85C19E00BA4D0A /* TokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51B63E81E65FA04002F4634 /* TokenType.swift */; };
 		DA5F59011E85C1B200BA4D0A /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5F58FF1E85C1B200BA4D0A /* MapboxDirections.framework */; };
 		DA5F59021E85C1B200BA4D0A /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5F59001E85C1B200BA4D0A /* Polyline.framework */; };
+		DA9CB7741F6C72D800AD2E21 /* PhraseName.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */; };
+		DA9CB7751F6C72D800AD2E21 /* PhraseName.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */; };
+		DA9CB7761F6C72D800AD2E21 /* PhraseName.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */; };
+		DA9CB7771F6C72D800AD2E21 /* PhraseName.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +91,7 @@
 		DA5F58F41E85C13700BA4D0A /* OSRMTextInstructions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OSRMTextInstructions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5F58FF1E85C1B200BA4D0A /* MapboxDirections.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxDirections.framework; path = Carthage/Build/watchOS/MapboxDirections.framework; sourceTree = "<group>"; };
 		DA5F59001E85C1B200BA4D0A /* Polyline.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Polyline.framework; path = Carthage/Build/watchOS/Polyline.framework; sourceTree = "<group>"; };
+		DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhraseName.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +215,7 @@
 				358D14561E5E355600ADE590 /* Info.plist */,
 				358D14571E5E355600ADE590 /* OSRMTextInstructions.h */,
 				358D14581E5E355600ADE590 /* OSRMTextInstructions.swift */,
+				DA9CB7731F6C72D800AD2E21 /* PhraseName.swift */,
 				C51B63E81E65FA04002F4634 /* TokenType.swift */,
 			);
 			path = OSRMTextInstructions;
@@ -636,6 +642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9CB7741F6C72D800AD2E21 /* PhraseName.swift in Sources */,
 				358D145B1E5E355600ADE590 /* OSRMTextInstructions.swift in Sources */,
 				C51B63E91E65FA04002F4634 /* TokenType.swift in Sources */,
 			);
@@ -645,6 +652,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9CB7751F6C72D800AD2E21 /* PhraseName.swift in Sources */,
 				DA5F58AC1E85B0A500BA4D0A /* OSRMTextInstructions.swift in Sources */,
 				DA5F58AD1E85B0A500BA4D0A /* TokenType.swift in Sources */,
 			);
@@ -662,6 +670,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9CB7761F6C72D800AD2E21 /* PhraseName.swift in Sources */,
 				DA5F58E41E85BE1500BA4D0A /* OSRMTextInstructions.swift in Sources */,
 				DA5F58E51E85BE1500BA4D0A /* TokenType.swift in Sources */,
 			);
@@ -679,6 +688,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9CB7771F6C72D800AD2E21 /* PhraseName.swift in Sources */,
 				DA5F58FD1E85C19E00BA4D0A /* OSRMTextInstructions.swift in Sources */,
 				DA5F58FE1E85C19E00BA4D0A /* TokenType.swift in Sources */,
 			);

--- a/OSRMTextInstructions.xcodeproj/project.pbxproj
+++ b/OSRMTextInstructions.xcodeproj/project.pbxproj
@@ -417,12 +417,13 @@
 					35EBDB5C1E5E1572006EB3CD = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = GJZR2MEM28;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					DA5F58921E85A32C00BA4D0A = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = GJZR2MEM28;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					DA5F589A1E85A32C00BA4D0A = {
@@ -433,6 +434,7 @@
 					DA5F58C71E85BA5D00BA4D0A = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = GJZR2MEM28;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					DA5F58CF1E85BA5D00BA4D0A = {
@@ -443,6 +445,7 @@
 					DA5F58F31E85C13700BA4D0A = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = GJZR2MEM28;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -906,6 +909,7 @@
 		DA5F58A41E85A32C00BA4D0A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -925,6 +929,7 @@
 				PRODUCT_NAME = OSRMTextInstructions;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -932,6 +937,7 @@
 		DA5F58A51E85A32C00BA4D0A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -998,6 +1004,7 @@
 		DA5F58DA1E85BA5D00BA4D0A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
@@ -1015,6 +1022,7 @@
 				PRODUCT_NAME = OSRMTextInstructions;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
@@ -1023,6 +1031,7 @@
 		DA5F58DB1E85BA5D00BA4D0A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
@@ -1085,6 +1094,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
@@ -1102,6 +1112,7 @@
 				PRODUCT_NAME = OSRMTextInstructions;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.1;
@@ -1112,6 +1123,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
@@ -1208,6 +1220,7 @@
 				DA5F58FB1E85C13700BA4D0A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -99,6 +99,16 @@ public class OSRMInstructionFormatter: Formatter {
         return instructions["constants"] as! [String: Any]
     }
     
+    /**
+     Returns a format string with the given name.
+     
+     - returns: A format string suitable for `String.replacingTokens(using:)`.
+     */
+    public func phrase(named name: PhraseName) -> String {
+        let phrases = instructions["phrase"] as! [String: String]
+        return phrases["\(name)"]!
+    }
+    
     func laneConfig(intersection: Intersection) -> String? {
         guard let approachLanes = intersection.approachLanes else {
             return ""
@@ -234,9 +244,7 @@ public class OSRMInstructionFormatter: Formatter {
             let isMotorway = roadClasses?.contains(.motorway) ?? false
             
             if let name = name, let ref = ref, name != ref, !isMotorway {
-                let phrases = instructions["phrase"] as! [String: String]
-                let phrase = phrases["name and ref"]!
-                wayName = phrase.replacingTokens(using: { (tokenType) -> String in
+                wayName = phrase(named: .nameWithCode).replacingTokens(using: { (tokenType) -> String in
                     switch tokenType {
                     case .wayName:
                         return modifyValueByKey?(.wayName, name) ?? name

--- a/OSRMTextInstructions/PhraseName.swift
+++ b/OSRMTextInstructions/PhraseName.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/**
+ Name of a phrase.
+ 
+ Use this type with `OSRMInstructionFormatter.phrase(named:)`.
+ */
+@objc(OSRMPhraseName)
+public enum PhraseName: Int, CustomStringConvertible {
+    case instructionWithDistance
+    case twoInstructions
+    case twoInstructionsWithDistance
+    case nameWithCode
+    
+    public init?(description: String) {
+        let name: PhraseName
+        switch description {
+        case "one in distance":
+            name = .instructionWithDistance
+        case "two linked":
+            name = .twoInstructions
+        case "two linked by distance":
+            name = .twoInstructionsWithDistance
+        case "name and ref":
+            name = .nameWithCode
+        default:
+            return nil
+        }
+        self.init(rawValue: name.rawValue)
+    }
+    
+    public var description: String {
+        switch self {
+        case .instructionWithDistance:
+            return "one in distance"
+        case .twoInstructions:
+            return "two linked"
+        case .twoInstructionsWithDistance:
+            return "two linked by distance"
+        case .nameWithCode:
+            return "name and ref"
+        }
+    }
+}


### PR DESCRIPTION
Added a method to look up a phrase format string by name. This allows clients to actually use the phrase support that was added in #38.

Also migrated to the Xcode 8.3 project format, since Xcode automatically accepted all its recommendations for some reason.

/cc @bsudekum