### PR TITLE
Update MapboxDirections.swift v0.16

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mapbox/MapboxDirections.swift" ~> 0.13
+github "mapbox/MapboxDirections.swift" ~> 0.16

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mapbox/MapboxDirections.swift" "v0.13.0"
+github "mapbox/MapboxDirections.swift" "v0.16.0"
 github "raphaelmor/Polyline" "v4.2.0"

--- a/OSRMTextInstructions.podspec
+++ b/OSRMTextInstructions.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "OSRMTextInstructions"
 
-  s.dependency "MapboxDirections.swift", "~> 0.13"
+  s.dependency "MapboxDirections.swift", "~> 0.16"
 
   s.prepare_command = "./json2plist.sh"
 

--- a/OSRMTextInstructions/OSRMTextInstructions.swift
+++ b/OSRMTextInstructions/OSRMTextInstructions.swift
@@ -267,11 +267,11 @@ extension NSAttributedString: Tokenized {
             return nil
         }
         
-        var type = step.maneuverType ?? .turn
-        let modifier = step.maneuverDirection?.description
+        var type = step.maneuverType
+        let modifier = step.maneuverDirection.description
         let mode = step.transportType
 
-        if type != .depart && type != .arrive && modifier == nil {
+        if type != .depart && type != .arrive && modifier == .none {
             return nil
         }
 
@@ -306,9 +306,9 @@ extension NSAttributedString: Tokenized {
         default:
             var typeInstructions = instructions[type.description] as! InstructionsByModifier
             let modesInstructions = instructions["modes"] as? InstructionsByModifier
-            if let mode = mode, let modesInstructions = modesInstructions, let modesInstruction = modesInstructions[mode.description] {
+            if let modesInstructions = modesInstructions, let modesInstruction = modesInstructions[mode.description] {
                 instructionObject = modesInstruction
-            } else if let modifier = modifier, let typeInstruction = typeInstructions[modifier] {
+            } else if let typeInstruction = typeInstructions[modifier] {
                 instructionObject = typeInstruction
             } else {
                 instructionObject = typeInstructions["default"]!
@@ -406,7 +406,7 @@ extension NSAttributedString: Tokenized {
             exitOrdinal = ordinalFormatter.string(from: exitIndex as NSNumber)!
         }
         let modifierConstants = constants["modifier"] as! [String: String]
-        let modifierConstant = modifierConstants[modifier ?? "straight"]!
+        let modifierConstant = modifierConstants[modifier == "none" ? "straight" : modifier]!
         var bearing: Int? = nil
         if step.finalHeading != nil { bearing = Int(step.finalHeading! as Double) }
 


### PR DESCRIPTION
Closes: https://github.com/Project-OSRM/osrm-text-instructions.swift/issues/55

This updates to the latest version of MapboxDirections.swift which introduced a few non-optional enums.

/cc @1ec5 @frederoni @Augustyniak 